### PR TITLE
feat: 범용 Modal 컴포넌트 작업

### DIFF
--- a/src/app/providers/modal/ModalRoot/index.tsx
+++ b/src/app/providers/modal/ModalRoot/index.tsx
@@ -1,0 +1,12 @@
+import { useModalStore } from '@/shared/store/useModalStore';
+import Modal from '../../../../shared/ui/Modal';
+
+const ModalRoot = () => {
+  const { isOpen, content, close } = useModalStore();
+
+  if (!isOpen || !content) return null;
+
+  return <Modal onClose={close}>{content}</Modal>;
+};
+
+export default ModalRoot;

--- a/src/app/providers/modal/ModalRoot/index.tsx
+++ b/src/app/providers/modal/ModalRoot/index.tsx
@@ -1,4 +1,4 @@
-import { useModalStore } from '@/shared/store/useModalStore';
+import { useModalStore } from '@/shared/model/modal/useModalStore';
 import Modal from '../../../../shared/ui/Modal';
 
 const ModalRoot = () => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,6 +10,7 @@ import nookies from 'nookies';
 import { verify } from 'jsonwebtoken';
 import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import type { User } from '@/features/auth/types/user';
+import ModalRoot from '@/app/providers/modal/ModalRoot';
 
 // initialUser를 받아오는 커스텀 AppProps
 interface MyAppProps extends AppProps {
@@ -57,6 +58,7 @@ export default function MyApp({
         <Header />
       </div>
       <Component {...pageProps} />
+      <ModalRoot />
     </>
   );
 }

--- a/src/shared/model/modal/useModalStore.ts
+++ b/src/shared/model/modal/useModalStore.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+import { ReactNode } from 'react';
+
+interface ModalState {
+  isOpen: boolean;
+  content: ReactNode | null;
+  open: (content: ReactNode) => void;
+  close: () => void;
+}
+
+export const useModalStore = create<ModalState>((set) => ({
+  isOpen: false,
+  content: null,
+  open: (content) => set({ isOpen: true, content }),
+  close: () => set({ isOpen: false, content: null }),
+}));

--- a/src/shared/ui/Modal/index.tsx
+++ b/src/shared/ui/Modal/index.tsx
@@ -1,0 +1,32 @@
+import { createPortal } from 'react-dom';
+import { useEffect, useState } from 'react';
+
+interface Props {
+  children: React.ReactNode;
+  onClose: () => void;
+}
+
+const Modal = ({ children, onClose }: Props) => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 bg-background-secondary/50 flex items-end md:items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-background-secondary p-6 shadow-lg w-full md:w-auto rounded-t-[24px] md:rounded-[12px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
## 🔍 What

- 범용 Modal 컴포넌트 제작
- 모바일 반응형 사이즈일 경우 하단 Modal 컴포넌트 디자인

## 📸 Screenshot (Optional)

### 일반적인 Modal
![스크린샷 2025-05-09 오후 12 57 23](https://github.com/user-attachments/assets/f1a509c9-bc5a-4578-b2f0-124cddb8eb5b)

### mobile에서의 Modal
![스크린샷 2025-05-09 오후 12 57 57](https://github.com/user-attachments/assets/9b57dcd6-fc2d-4e96-aea5-77f91e6aef7b)

## ✅ Checklist

- [x] 기능이 정상 동작함
- [x] 관련 문서 및 주석 최신화
- [x] 불필요한 콘솔/코드 제거
- [x] 코드 컨벤션에 맞게 작성됨

## 💬 Comment for Reviewer

- zustand를 사용해서 Modal의 상태 값을 전역으로 관리하도록 설계했습니다.