### PR TITLE
fix: 로그인 ui 구현

### DIFF
--- a/src/features/auth/ui/Login.tsx
+++ b/src/features/auth/ui/Login.tsx
@@ -8,11 +8,11 @@ export default function LoginPage() {
   const router = useRouter();
 
   useEffect(() => {
-    // if (user) router.replace('/');
+    if (user) router.replace('/');
   }, [user, router]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="h-full max-w-[460px] mx-auto flex items-start md:items-center justify-center">
       <LoginForm />
     </div>
   );

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -1,64 +1,112 @@
 import { useState } from 'react';
-// import { useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import Input from '@/shared/ui/Input';
+import Button from '@/shared/ui/button';
+import Link from 'next/link';
 
 export default function LoginForm() {
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
-  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [emailErrorMessage, setEmailErrorMessage] = useState<string>('');
+  const [passwordErrorMessage, setPasswordErrorMessage] = useState<string>('');
   const login = useAuthStore((s) => s.login);
-  // const router = useRouter();
+  const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
       await login(email, password);
-      // router.push('/');
+      router.push('/');
     } catch {
       alert('로그인에 실패했습니다. 이메일 또는 비밀번호를 확인해주세요.');
     }
   };
 
-  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+  const handleEmailInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const value = e.target.value;
 
     if (!value) {
-      setErrorMessage('값을 입력해주세요.');
+      setEmailErrorMessage('이메일을 입력해주세요.');
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
-      setErrorMessage('올바른 이메일 형식이 아닙니다.');
+      setEmailErrorMessage('올바른 이메일 형식이 아닙니다.');
     } else {
-      setErrorMessage('');
+      setEmailErrorMessage('');
     }
   };
 
+  const handlePasswordInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+
+    if (!value) {
+      setPasswordErrorMessage('비밀번호를 입력해 주세요.');
+    } else {
+      setPasswordErrorMessage('');
+    }
+  };
+
+  const isFormValid =
+    email !== '' &&
+    password !== '' &&
+    !emailErrorMessage &&
+    !passwordErrorMessage;
+
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="mx-auto mt-20 max-w-[280px] w-full"
-    >
-      <Input
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="이메일을 입력하세요."
-        onBlur={handleBlur}
-        errorMessage={errorMessage}
-      />
-
-      <Input
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="비밀번호를 입력해주세요."
-      />
-
-      <button
-        type="submit"
-        className="w-full p-2 bg-blue-600 text-white rounded"
-      >
+    <form onSubmit={handleSubmit} className="mt-15 w-full">
+      <h2 className="text-text-primary text-2xl-m text-center mb-6 lg:text-4xl-m lg:mb-20">
         로그인
-      </button>
+      </h2>
+
+      <div className="mb-10">
+        <div className="mb-6">
+          <label
+            htmlFor="emailInput"
+            className="block text-text-primary text-lg-m mb-3"
+          >
+            이메일
+          </label>
+          <Input
+            type="email"
+            id="emailInput"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="이메일을 입력하세요."
+            onBlur={handleEmailInputBlur}
+            errorMessage={emailErrorMessage}
+          />
+        </div>
+
+        <div className="mb-3">
+          <label
+            htmlFor="emailInput"
+            className="block text-text-primary text-lg-m mb-3"
+          >
+            비밀번호
+          </label>
+          <Input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="비밀번호를 입력해주세요."
+            onBlur={handlePasswordInputBlur}
+            errorMessage={passwordErrorMessage}
+          />
+        </div>
+
+        <p className="text-icon-brand underline text-right text-md-m md:text-lg-m">
+          비밀번호를 잊으셨나요?
+        </p>
+      </div>
+
+      <Button className="mb-6" disabled={!isFormValid}>
+        로그인
+      </Button>
+      <p className="text-center text-md-m md:text-lg-m text-text-primary">
+        아직 계정이 없으신가요?{'  '}
+        <Link href={'/signup'} className="text-icon-brand underline">
+          가입하기
+        </Link>
+      </p>
     </form>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -27,10 +27,12 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <>
-      <div className="mb-15">
-        <Header />
-      </div>
-      <Component {...pageProps} />
+      {/* <div className="mb-15"> */}
+      <Header />
+      {/* </div> */}
+      <main className="bg-background-primary py-6 px-4 h-screen">
+        <Component {...pageProps} />
+      </main>
       <ModalRoot />
     </>
   );

--- a/src/shared/ui/Input/index.tsx
+++ b/src/shared/ui/Input/index.tsx
@@ -4,25 +4,16 @@ import visibleIcon from '@/shared/assets/images/visibility_on.svg';
 import inVisibleIcon from '@/shared/assets/images/visibility_off.svg';
 import { useState } from 'react';
 
-type InputSize = 'small' | 'large';
-
-const sizeStyle: Record<InputSize, string> = {
-  small: 'py-[13.5px] px-[18px] text-md-r',
-  large: 'py-[14.5px] px-4 text-lg-r',
-};
-
 interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  size?: InputSize;
   placeholder?: string;
   type?: string;
   errorMessage?: string;
 }
 
 const Input = ({
-  size = 'large',
   placeholder,
   type = 'text',
   className,
@@ -31,45 +22,47 @@ const Input = ({
   ...rest
 }: InputProps) => {
   const [visible, setVisible] = useState(false);
-  const base =
-    'rounded-[12px] bg-background-secondary outline-none w-full border';
 
   return (
-    <div className="relative">
-      <input
-        className={classNames(
-          base,
-          sizeStyle[size],
-          {
-            'border-danger': errorMessage,
-            'hover:border hover:border-interaction-hover':
-              !errorMessage && !disabled,
-            'focus:border focus:border-interaction-focus': !errorMessage,
-          },
-          className,
-          disabled
-            ? 'bg-background-tertiary text-text-disabled'
-            : 'bg-background-secondary text-text-primary'
-        )}
-        disabled={disabled}
-        placeholder={placeholder}
-        type={type === 'password' && visible ? 'text' : type}
-        {...rest}
-      />
-      {type === 'password' && (
-        <Image
-          src={visible ? visibleIcon : inVisibleIcon}
-          width={24}
-          height={24}
-          alt="보기 아이콘"
-          onClick={() => setVisible((prev) => !prev)}
-          className="absolute top-1/2 -translate-y-1/2 right-4 cursor-pointer"
+    <>
+      <div className="relative">
+        <input
+          className={classNames(
+            'rounded-[12px] bg-background-secondary outline-none w-full border',
+            'py-[13.5px] px-[18px] text-md-r',
+            'md:py-[14.5px] md:px-4 md:text-lg-r',
+            {
+              'border-danger': errorMessage,
+              'hover:border hover:border-interaction-hover':
+                !errorMessage && !disabled,
+              'focus:border focus:border-interaction-focus': !errorMessage,
+            },
+            className,
+            disabled
+              ? 'bg-background-tertiary text-text-disabled'
+              : 'bg-background-secondary text-text-primary border-[#F8FAFC1A]'
+          )}
+          disabled={disabled}
+          placeholder={placeholder}
+          type={type === 'password' && visible ? 'text' : type}
+          {...rest}
         />
-      )}
+
+        {type === 'password' && (
+          <Image
+            src={visible ? visibleIcon : inVisibleIcon}
+            width={24}
+            height={24}
+            alt="보기 아이콘"
+            onClick={() => setVisible((prev) => !prev)}
+            className="absolute top-1/2 -translate-y-1/2 right-4 cursor-pointer"
+          />
+        )}
+      </div>
       {errorMessage && (
         <p className="mt-1 text-sm text-danger">{errorMessage}</p>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/shared/ui/button/index.tsx
+++ b/src/shared/ui/button/index.tsx
@@ -7,6 +7,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
   variant?: ButtonVariant;
   size?: ButtonSize;
+  disabled: boolean;
 }
 
 const variantStyles: Record<ButtonVariant, string> = {


### PR DESCRIPTION
## 🔍 What

- 로그인 UI 구현
- 기존 Input 컴포넌트에서 size prop를 삭제하고 반응형에 맞춰서 size 변동하도록 변경
- _app.tsx에서 최소 padding 값 설정

</br>

## 📸 Screenshot (Optional)

### PC 반응형 로그인 UI
![스크린샷 2025-05-17 오전 8 10 28](https://github.com/user-attachments/assets/ff0bb489-2b6d-411b-b859-64fd4e9eb3f0)

### Tablet 반응형 로그인 UI
![스크린샷 2025-05-17 오전 8 11 11](https://github.com/user-attachments/assets/06bf55aa-8d58-4387-bfca-1876d272abd2)

### Mobile 반응형 로그인 UI
![스크린샷 2025-05-17 오전 8 11 29](https://github.com/user-attachments/assets/1e0baefb-b73e-4927-8bed-13f5b79fd753)

</br>

## ✅ Checklist

- [x] 기능이 정상 동작함
- [x] 관련 문서 및 주석 최신화
- [x] 불필요한 콘솔/코드 제거
- [x] 코드 컨벤션에 맞게 작성됨